### PR TITLE
Add GitHub Action to download and process MP3 files

### DIFF
--- a/.github/workflows/download_and_process.yml
+++ b/.github/workflows/download_and_process.yml
@@ -10,7 +10,8 @@ on:
 
 jobs:
   download-and-process:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    name: downloader
 
     env:
       PYTHONPATH: /home/junfan/test/venv/lib/python3.10
@@ -27,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U yt-dlp
+        pip install yt-dlp whisper-jax
 
     - name: Download MP3 from YouTube
       run: yt-dlp -x --audio-format mp3 -o "output.mp3" "https://www.youtube.com/watch?v=LG9G4aA28rU"
@@ -42,6 +43,7 @@ jobs:
 
   process-mp3:
     runs-on: self-hosted
+    name: runner
 
     env:
       PYTHONPATH: /home/junfan/test/venv/lib/python3.10
@@ -58,4 +60,3 @@ jobs:
         pipeline = FlaxWhisperPipline("openai/whisper-large-v2")
         text = pipeline("output.mp3")
         echo $text
-      shell: python

--- a/.github/workflows/download_and_process.yml
+++ b/.github/workflows/download_and_process.yml
@@ -1,0 +1,70 @@
+name: Download and Process MP3
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  download-and-process:
+    runs-on: ubuntu-latest
+
+    env:
+      PYTHONPATH: /home/junfan/test/venv/lib/python3.10
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install youtube-dl whisper-jax
+
+    - name: Download MP3 from YouTube
+      run: youtube-dl -x --audio-format mp3 <YOUTUBE_URL>
+
+    - name: Commit MP3 to repository
+      run: |
+        git config --global user.name 'github-actions'
+        git config --global user.email 'github-actions@github.com'
+        git add *.mp3
+        git commit -m 'Add downloaded MP3 file'
+        git push
+
+  process-mp3:
+    runs-on: self-hosted
+
+    env:
+      PYTHONPATH: /home/junfan/test/venv/lib/python3.10
+
+    needs: download-and-process
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install whisper-jax
+
+    - name: Process MP3 with Whisper JAX
+      run: |
+        from whisper_jax import FlaxWhisperPipline
+        pipeline = FlaxWhisperPipline("openai/whisper-large-v2")
+        text = pipeline("audio.mp3")
+        echo $text

--- a/.github/workflows/download_and_process.yml
+++ b/.github/workflows/download_and_process.yml
@@ -52,19 +52,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install whisper-jax
-
     - name: Process MP3 with Whisper JAX
       run: |
         from whisper_jax import FlaxWhisperPipline
         pipeline = FlaxWhisperPipline("openai/whisper-large-v2")
         text = pipeline("output.mp3")
         echo $text
+      shell: python

--- a/.github/workflows/download_and_process.yml
+++ b/.github/workflows/download_and_process.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install yt-dlp whisper-jax
+        pip install -U yt-dlp
 
     - name: Download MP3 from YouTube
       run: yt-dlp -x --audio-format mp3 -o "output.mp3" "https://www.youtube.com/watch?v=LG9G4aA28rU"

--- a/.github/workflows/download_and_process.yml
+++ b/.github/workflows/download_and_process.yml
@@ -27,10 +27,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install youtube-dl whisper-jax
+        pip install yt-dlp whisper-jax
 
     - name: Download MP3 from YouTube
-      run: youtube-dl -x --audio-format mp3 <YOUTUBE_URL>
+      run: yt-dlp -x --audio-format mp3 -o "output.mp3" "https://www.youtube.com/watch?v=LG9G4aA28rU"
 
     - name: Commit MP3 to repository
       run: |
@@ -66,5 +66,5 @@ jobs:
       run: |
         from whisper_jax import FlaxWhisperPipline
         pipeline = FlaxWhisperPipline("openai/whisper-large-v2")
-        text = pipeline("audio.mp3")
+        text = pipeline("output.mp3")
         echo $text

--- a/README.md
+++ b/README.md
@@ -39,20 +39,50 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install youtube-dl whisper-jax
+        pip install yt-dlp whisper-jax
 
     - name: Download MP3 from YouTube
-      run: youtube-dl -x --audio-format mp3 <YOUTUBE_URL>
+      run: yt-dlp -x --audio-format mp3 -o "output.mp3" "https://www.youtube.com/watch?v=LG9G4aA28rU"
+
+    - name: Commit MP3 to repository
+      run: |
+        git config --global user.name 'github-actions'
+        git config --global user.email 'github-actions@github.com'
+        git add *.mp3
+        git commit -m 'Add downloaded MP3 file'
+        git push
+
+  process-mp3:
+    runs-on: self-hosted
+
+    env:
+      PYTHONPATH: /home/junfan/test/venv/lib/python3.10
+
+    needs: download-and-process
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install whisper-jax
 
     - name: Process MP3 with Whisper JAX
       run: |
         from whisper_jax import FlaxWhisperPipline
         pipeline = FlaxWhisperPipline("openai/whisper-large-v2")
-        text = pipeline("audio.mp3")
+        text = pipeline("output.mp3")
         echo $text
 ```
 
-3. Replace `<YOUTUBE_URL>` with the actual YouTube URL you want to download the MP3 from.
+3. Replace the YouTube URL in the `Download MP3 from YouTube` step with the actual YouTube URL you want to download the MP3 from.
 
 4. Commit and push the changes to your repository.
 
@@ -60,7 +90,7 @@ jobs:
 
 This workflow requires the following dependencies:
 
-- `youtube-dl`: A command-line program to download videos from YouTube and other video sites.
+- `yt-dlp`: A command-line program to download videos from YouTube and other video sites.
 - `whisper-jax`: A package for processing audio files with the Whisper JAX pipeline.
 
 Make sure to install these dependencies in your Python environment.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# GitHub Action: Download and Process MP3
+
+This repository contains a GitHub Action workflow to download an MP3 file from a given YouTube URL and process it with the Whisper JAX package.
+
+## Usage
+
+To use this GitHub Action workflow, follow these steps:
+
+1. Create a new file in your repository at `.github/workflows/download_and_process.yml`.
+2. Copy the following content into the file:
+
+```yaml
+name: Download and Process MP3
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  download-and-process:
+    runs-on: ubuntu-latest
+
+    env:
+      PYTHONPATH: /home/junfan/test/venv/lib/python3.10
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install youtube-dl whisper-jax
+
+    - name: Download MP3 from YouTube
+      run: youtube-dl -x --audio-format mp3 <YOUTUBE_URL>
+
+    - name: Process MP3 with Whisper JAX
+      run: |
+        from whisper_jax import FlaxWhisperPipline
+        pipeline = FlaxWhisperPipline("openai/whisper-large-v2")
+        text = pipeline("audio.mp3")
+        echo $text
+```
+
+3. Replace `<YOUTUBE_URL>` with the actual YouTube URL you want to download the MP3 from.
+
+4. Commit and push the changes to your repository.
+
+## Dependencies
+
+This workflow requires the following dependencies:
+
+- `youtube-dl`: A command-line program to download videos from YouTube and other video sites.
+- `whisper-jax`: A package for processing audio files with the Whisper JAX pipeline.
+
+Make sure to install these dependencies in your Python environment.


### PR DESCRIPTION
Fixes #1

Add a GitHub Action workflow to download and process MP3 files from YouTube URLs.

* **Workflow File**: Add `.github/workflows/download_and_process.yml`
  - Trigger on push and pull request events.
  - Set up Python environment with specified PYTHONPATH.
  - Install dependencies `youtube-dl` and `whisper-jax`.
  - Download MP3 from YouTube URL and commit to the repository.
  - Process the committed MP3 file with `FlaxWhisperPipline` on a self-hosted runner.

* **Documentation**: Add `README.md`
  - Include instructions on how to use the new GitHub Action workflow.
  - Provide example usage of the workflow.
  - Mention dependencies `youtube-dl` and `whisper-jax`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/xihajun/test-llm/pull/2?shareId=6e98a12d-2f81-4f6f-b2d8-b830ce43a163).